### PR TITLE
Update texture creation to not rely on `SDL_image`

### DIFF
--- a/internal/gfx/renderer.go
+++ b/internal/gfx/renderer.go
@@ -1,0 +1,103 @@
+package gfx
+
+import (
+	"bytes"
+	"image"
+	"log"
+	"os"
+
+	_ "image/png" // Register the png format
+
+	"github.com/veandco/go-sdl2/sdl"
+)
+
+var textureCache = map[ScaleQuality]map[string]*Texture{
+	ScaleNearest:     make(map[string]*Texture),
+	ScaleLinear:      make(map[string]*Texture),
+	ScaleAnisotropic: make(map[string]*Texture),
+}
+
+type ScaleQuality string
+
+const (
+	ScaleNearest     ScaleQuality = "nearest"
+	ScaleLinear      ScaleQuality = "linear"
+	ScaleAnisotropic ScaleQuality = "best"
+)
+
+type Renderer struct {
+	*sdl.Renderer
+	pixelFormat uint32
+}
+
+func NewRenderer(window *sdl.Window) (*Renderer, error) {
+	pixelFormat, err := window.GetPixelFormat()
+	if err != nil {
+		return nil, err
+	}
+
+	renderer, err := sdl.CreateRenderer(window, -1, sdl.RENDERER_ACCELERATED)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &Renderer{
+		Renderer:    renderer,
+		pixelFormat: pixelFormat,
+	}
+
+	return r, nil
+}
+
+func (rn *Renderer) NewTexture(imagePath string, scaleQuality ScaleQuality) *Texture {
+	if t := textureCache[scaleQuality][imagePath]; t != nil {
+		return t
+	}
+
+	b, err := os.ReadFile(imagePath)
+	if err != nil {
+		panic(err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(b))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, string(scaleQuality))
+
+	bounds := img.Bounds()
+
+	texture, err := rn.CreateTexture(rn.pixelFormat, sdl.TEXTUREACCESS_TARGET, int32(bounds.Max.X), int32(bounds.Max.Y))
+	if err != nil {
+		panic(err)
+	}
+
+	texture.SetBlendMode(sdl.BLENDMODE_BLEND)
+
+	rn.SetRenderTarget(texture)
+	rn.SetDrawColor(255, 255, 255, 0)
+	rn.Clear()
+
+	for y := 0; y < bounds.Max.Y; y++ {
+		for x := 0; x < bounds.Max.X; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+
+			rn.SetDrawColor(uint8(r), uint8(g), uint8(b), uint8(a))
+			rn.DrawPoint(int32(x), int32(y))
+		}
+	}
+
+	rn.SetRenderTarget(nil)
+
+	t := &Texture{
+		renderer: rn.Renderer,
+		texture:  texture,
+		width:    bounds.Max.X,
+		height:   bounds.Max.Y,
+	}
+
+	textureCache[scaleQuality][imagePath] = t
+
+	return t
+}

--- a/internal/gfx/texture.go
+++ b/internal/gfx/texture.go
@@ -3,61 +3,14 @@ package gfx
 import (
 	"math"
 
-	"github.com/veandco/go-sdl2/img"
 	"github.com/veandco/go-sdl2/sdl"
 )
-
-type ScaleQuality string
-
-const (
-	ScaleNearest     ScaleQuality = "nearest"
-	ScaleLinear      ScaleQuality = "linear"
-	ScaleAnisotropic ScaleQuality = "best"
-)
-
-var textures = map[ScaleQuality]map[string]*Texture{
-	ScaleNearest:     make(map[string]*Texture),
-	ScaleLinear:      make(map[string]*Texture),
-	ScaleAnisotropic: make(map[string]*Texture),
-}
 
 type Texture struct {
 	renderer *sdl.Renderer
 	texture  *sdl.Texture
 	width    int
 	height   int
-}
-
-func NewTexture(renderer *sdl.Renderer, scaleQuality ScaleQuality, path string) *Texture {
-	if t, ok := textures[scaleQuality][path]; ok {
-		return t
-	}
-
-	sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, string(scaleQuality))
-
-	image, err := img.Load(path)
-	if err != nil {
-		panic(err)
-	}
-	defer image.Free()
-
-	texture, err := renderer.CreateTextureFromSurface(image)
-	if err != nil {
-		panic(err)
-	}
-
-	texture.SetBlendMode(sdl.BLENDMODE_BLEND)
-
-	t := &Texture{
-		renderer: renderer,
-		texture:  texture,
-		width:    int(image.W),
-		height:   int(image.H),
-	}
-
-	textures[scaleQuality][path] = t
-
-	return t
 }
 
 func (t *Texture) SetAlphaMod(a float64) {


### PR DESCRIPTION
These changes update texture creation to no longer rely on `SDL_image` and instead load images from disk and decode them using the standard library's `image.Decode` function.

Currently only the png format is registerer with the blank `_ "image/png"` import, but we can add others later if needed.

A couple of other changes around the implementation details of textures and renderers have changed, but nothing major.

The main upside to this is that we won't have to include `SDL_image.dll`, `zlib1.dll`, and `libpng16-16.dll` with distributions of binaries anymore.