### PR TITLE
Mouse input and `Vec2` changes

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -34,11 +34,19 @@ type Device struct {
 }
 
 var Mouse = struct {
+	*Device
 	current  map[string]*Button
 	previous map[string]*Button
 	Position linalg.Vec2
 	Delta    linalg.Vec2
 }{
+	Device: NewDevice(BindingMap{
+		"left":   {"mouse:left"},
+		"middle": {"mouse:middle"},
+		"right":  {"mouse:right"},
+		"extra1": {"mouse:extra1"},
+		"extra2": {"mouse:extra2"},
+	}),
 	current:  newMouseButtons(),
 	previous: newMouseButtons(),
 }

--- a/internal/input/mouse.go
+++ b/internal/input/mouse.go
@@ -1,0 +1,21 @@
+package input
+
+import "github.com/veandco/go-sdl2/sdl"
+
+func newMouseButtons() map[string]*Button {
+	return map[string]*Button{
+		"left":   {},
+		"middle": {},
+		"right":  {},
+		"extra1": {},
+		"extra2": {},
+	}
+}
+
+var mouseMasks = map[string]uint32{
+	"left":   sdl.ButtonLMask(),
+	"middle": sdl.ButtonMMask(),
+	"right":  sdl.ButtonRMask(),
+	"extra1": sdl.ButtonX1Mask(),
+	"extra2": sdl.ButtonX2Mask(),
+}

--- a/internal/linalg/vec2.go
+++ b/internal/linalg/vec2.go
@@ -32,7 +32,7 @@ func (v Vec2) Mul(rhs float64) Vec2 {
 	}
 }
 
-func (v Vec2) Negate() Vec2 {
+func (v Vec2) Neg() Vec2 {
 	return Vec2{
 		X: -v.X,
 		Y: -v.Y,
@@ -43,24 +43,24 @@ func (v Vec2) Dot(rhs Vec2) float64 {
 	return v.X*rhs.X + v.Y*rhs.Y
 }
 
-func (v Vec2) MagnitudeSq() float64 {
+func (v Vec2) MagSq() float64 {
 	// The result of the dot product of a vector with itself is the magnitude
 	// squared because the dot product is the scalar projection of the lhs
 	// vector onto the rhs vector which is then scaled by rhs vector's magnitude
 	return v.Dot(v)
 }
 
-func (v Vec2) Magnitude() float64 {
-	return math.Sqrt(v.MagnitudeSq())
+func (v Vec2) Mag() float64 {
+	return math.Sqrt(v.MagSq())
 }
 
-func (v Vec2) Normalise() Vec2 {
+func (v Vec2) Norm() Vec2 {
 	// A zero vector cannot be normalised
 	if v.X == 0 && v.Y == 0 {
 		return v
 	}
 
-	reciprocal := 1.0 / v.Magnitude()
+	reciprocal := 1.0 / v.Mag()
 
 	return v.Mul(reciprocal)
 }


### PR DESCRIPTION
These changes add button processing for 5 mouse button bindings:
- `mouse:left`
- `mouse:middle`
- `mouse:right`
- `mouse:extra1`
- `mouse:extra2`

These work in the same way as any other keyboard button does.

It also adds mouse window coordinates which are attached to a global `input.Mouse` object.
Since these coordinates can't be represented in a nice way as a button they must be accessed as...
```go
input.Mouse.Position.X
input.Mouse.Position.Y
input.Mouse.Delta.X
input.Mouse.Delta.Y
```
...where `Position` is the current position of the cursor in the window, and `Delta` is the amount the mouse moved since the last frame.
`input.Mouse.Position` and `input.Mouse.Delta` cannot be bound as device inputs.

Also, unrelated to mouse input, I shortened the `linalg.Vec2` method names.
So:
- `v.Negate` -> `v.Neg`
- `v.Magnitude` -> `v.Mag`
- `v.MagnitudeSq` -> `v.MagSq`
- `v.Normalise` -> `v.Norm`

This will reduce on typing, but also reduce typos between British/American spellings.