### PR TITLE
Logical size input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/robotscone/adventure
 
 go 1.17
 
-require github.com/veandco/go-sdl2 v0.4.12
+require github.com/veandco/go-sdl2 v0.4.14

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/veandco/go-sdl2 v0.4.12 h1:zY/yQAR+fWmLquiOSjDaOV9GjRHaFtFwnFjLSIIzL3I=
-github.com/veandco/go-sdl2 v0.4.12/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=
+github.com/veandco/go-sdl2 v0.4.14 h1:ShagETHJG8NCWVn9rwfZ9WLIaN4c2maw3gfFH+9DlOg=
+github.com/veandco/go-sdl2 v0.4.14/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/robotscone/adventure/internal/gfx"
 	"github.com/robotscone/adventure/internal/linalg"
 	"github.com/veandco/go-sdl2/sdl"
 )
@@ -110,10 +111,16 @@ func setButtonState(current, previous *Button, value float64, now time.Time) {
 	}
 }
 
-func Update() {
+func Update(renderer *gfx.Renderer) {
 	now := time.Now()
 	mouseX, mouseY, mouseState := sdl.GetMouseState()
 	keyboardState := sdl.GetKeyboardState()
+
+	if renderer != nil {
+		logicalMouseX, logicalMouseY := renderer.RenderWindowToLogical(int(mouseX), int(mouseY))
+
+		mouseX, mouseY = int32(logicalMouseX), int32(logicalMouseY)
+	}
 
 	mousePreviousX := Mouse.Position.X
 	mousePreviousY := Mouse.Position.Y


### PR DESCRIPTION
These changes update the `input.Update` function to take an optional `*gfx.Renderer` which is used to convert the real mouse window position into its equivalent logical position.

For example, if the real window width is 800px and the mouse's real X position is at 400px, then it should be converted to 200px if the renderer's logical width is set to 400px.

If no renderer is supplied then no conversion will take place.