### PR TITLE
Fix texture bleeding at certain resolutions

### DIFF
--- a/internal/gfx/texture.go
+++ b/internal/gfx/texture.go
@@ -11,6 +11,7 @@ type Texture struct {
 	texture  *sdl.Texture
 	width    int
 	height   int
+	dst      sdl.FRect
 }
 
 func (t *Texture) SetAlphaMod(a float64) {
@@ -32,7 +33,30 @@ func (t *Texture) Draw(src *sdl.Rect, dst *sdl.FRect, flip Flip) {
 		rendererFlip = sdl.FLIP_NONE
 	}
 
-	t.renderer.CopyExF(t.texture, src, dst, 0.0, nil, rendererFlip)
+	// The value added to the destination X and Y here is a hack to try and
+	// prevent texture bleeding when low logical renderer sizes are stretched
+	// to fit high resolution window sizes
+	//
+	// If these values don't solve the problem for certain resolutions then they
+	// can be changed, but the higher they are the more noticeable the offset
+	// of the final render will become
+	// For example, if they're set to 0.5 then it's obvious that there's half
+	// a pixel offset of the final render from the top and left sides because
+	// you can see a small black line
+	//
+	// The more technically correct way to fix this issue would be to create
+	// a render target texture that's the same size as the logical size, render
+	// everything into that texture, then remove the render target and copy
+	// the entire render texture to the window
+	// The problem with that approach is that movement of sprites in the world
+	// becomes noticeably jittery/jagged, which is why we're taking this
+	// approach instead
+	t.dst.X = dst.X + 0.01
+	t.dst.Y = dst.Y + 0.01
+	t.dst.W = dst.W
+	t.dst.H = dst.H
+
+	t.renderer.CopyExF(t.texture, src, &t.dst, 0.0, nil, rendererFlip)
 }
 
 func (t *Texture) Destroy() {


### PR DESCRIPTION
I've been having a problem with texture bleeding in tile maps when the small textures we use get scaled up to the size of a full resolution window.

This only happens at specific resolutions that are in between mulitples of logical sizes.

One fix would be to just call `SDL_RenderSetIntegerScale` and enable integer scaling; this would make SDL2 scale to the lower multiple, but it would mean the final render wouldn't fill the entire window, so that option's out.

The next more technically "correct" fix is to create a render target texture that's the same size as the logical size, render everything into that texture, then remove the render target and copy the entire render texture to the window. The problem with that approach is that movement of sprites in the world becomes noticeably jittery/jagged, so although it's more "correct" it also looks worse.

Because of issues in those two fixes I've decided to just offset the destination rect that we draw to in the window for each texture by `0.01`. This fixes the issue for me at all of the resolutions I've tested, but if it's still an issue for other resolutions we can tweak the values.