### PR TITLE
Initial text renderer support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/robotscone/adventure
 
-go 1.17
+go 1.18
 
-require github.com/veandco/go-sdl2 v0.4.14
+require (
+	github.com/veandco/go-sdl2 v0.4.21
+	golang.org/x/image v0.0.0-20220601225756-64ec528b34cd
+)
+
+require golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
-github.com/veandco/go-sdl2 v0.4.14 h1:ShagETHJG8NCWVn9rwfZ9WLIaN4c2maw3gfFH+9DlOg=
-github.com/veandco/go-sdl2 v0.4.14/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=
+github.com/veandco/go-sdl2 v0.4.21 h1:85AtFYv3vSPZvyOOxkJ03sHoJe8ESjPSZLr0KueQtVY=
+github.com/veandco/go-sdl2 v0.4.21/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=
+golang.org/x/image v0.0.0-20220601225756-64ec528b34cd h1:9NbNcTg//wfC5JskFW4Z3sqwVnjmJKHxLAol1bW2qgw=
+golang.org/x/image v0.0.0-20220601225756-64ec528b34cd/go.mod h1:doUCurBvlfPMKfmIpRIywoHmhN3VyhnoFDbvIEWF4hY=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/gfx/animation.go
+++ b/internal/gfx/animation.go
@@ -2,8 +2,6 @@ package gfx
 
 import (
 	"time"
-
-	"github.com/veandco/go-sdl2/sdl"
 )
 
 type Flip byte
@@ -22,7 +20,7 @@ const (
 )
 
 type Frame struct {
-	src  sdl.Rect
+	src  Rect
 	flip Flip
 }
 
@@ -36,13 +34,13 @@ type Animation struct {
 	timing   timingKind
 }
 
-func (a *Animation) AddFrame(x, y, w, h int, flip Flip) {
+func (a *Animation) AddFrame(x, y, width, height int, flip Flip) {
 	a.frames = append(a.frames, &Frame{
-		src: sdl.Rect{
-			X: int32(x),
-			Y: int32(y),
-			W: int32(w),
-			H: int32(h),
+		src: Rect{
+			X:      x,
+			Y:      y,
+			Width:  width,
+			Height: height,
 		},
 		flip: flip,
 	})

--- a/internal/gfx/renderer.go
+++ b/internal/gfx/renderer.go
@@ -25,6 +25,20 @@ const (
 	ScaleAnisotropic ScaleQuality = "best"
 )
 
+type Rect struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+type FRect struct {
+	X      float64
+	Y      float64
+	Width  float64
+	Height float64
+}
+
 type Renderer struct{ *sdl.Renderer }
 
 func NewRenderer(window *sdl.Window) (*Renderer, error) {
@@ -38,21 +52,7 @@ func NewRenderer(window *sdl.Window) (*Renderer, error) {
 	return &Renderer{Renderer: renderer}, nil
 }
 
-func (rn *Renderer) NewTexture(imagePath string, scaleQuality ScaleQuality) *Texture {
-	if t := textureCache[scaleQuality][imagePath]; t != nil {
-		return t
-	}
-
-	b, err := os.ReadFile(imagePath)
-	if err != nil {
-		panic(err)
-	}
-
-	img, _, err := image.Decode(bytes.NewReader(b))
-	if err != nil {
-		log.Fatal(err)
-	}
-
+func (rn *Renderer) NewTexture(img image.Image, scaleQuality ScaleQuality) *Texture {
 	sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, string(scaleQuality))
 
 	bounds := img.Bounds()
@@ -68,28 +68,70 @@ func (rn *Renderer) NewTexture(imagePath string, scaleQuality ScaleQuality) *Tex
 	pitch := bounds.Max.X * bpp
 	pixels := make([]byte, pitch*bounds.Max.Y)
 
-	for y := 0; y < bounds.Max.Y; y++ {
-		for x := 0; x < bounds.Max.X; x++ {
-			r, g, b, a := img.At(x, y).RGBA()
-			offset := y*pitch + x*bpp
+	if gray, ok := img.(*image.Gray); ok {
+		for y := 0; y < bounds.Max.Y; y++ {
+			for x := 0; x < bounds.Max.X; x++ {
+				offset := y*pitch + x*bpp
 
-			pixels[offset+0] = byte(r)
-			pixels[offset+1] = byte(g)
-			pixels[offset+2] = byte(b)
-			pixels[offset+3] = byte(a)
+				pixels[offset+0] = 0xFF
+				pixels[offset+1] = 0xFF
+				pixels[offset+2] = 0xFF
+				pixels[offset+3] = gray.GrayAt(x, y).Y
+			}
+		}
+	} else {
+		for y := 0; y < bounds.Max.Y; y++ {
+			for x := 0; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				offset := y*pitch + x*bpp
+
+				pixels[offset+0] = byte(r)
+				pixels[offset+1] = byte(g)
+				pixels[offset+2] = byte(b)
+				pixels[offset+3] = byte(a)
+			}
 		}
 	}
 
 	texture.Update(nil, pixels, pitch)
 
 	t := &Texture{
-		renderer: rn.Renderer,
+		renderer: rn,
 		texture:  texture,
 		width:    bounds.Max.X,
 		height:   bounds.Max.Y,
 	}
 
+	return t
+}
+
+func (rn *Renderer) NewTextureFromFile(imagePath string, scaleQuality ScaleQuality) *Texture {
+	if t := textureCache[scaleQuality][imagePath]; t != nil {
+		return t
+	}
+
+	b, err := os.ReadFile(imagePath)
+	if err != nil {
+		panic(err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(b))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	t := rn.NewTexture(img, scaleQuality)
+
 	textureCache[scaleQuality][imagePath] = t
 
 	return t
+}
+
+func (rn *Renderer) NewSizedTexture(texture *sdl.Texture, width, height int) *Texture {
+	return &Texture{
+		renderer: rn,
+		texture:  texture,
+		width:    width,
+		height:   height,
+	}
 }

--- a/internal/gfx/sprite.go
+++ b/internal/gfx/sprite.go
@@ -2,14 +2,12 @@ package gfx
 
 import (
 	"fmt"
-
-	"github.com/veandco/go-sdl2/sdl"
 )
 
 type Sprite struct {
 	*Texture
-	src        sdl.Rect
-	dst        sdl.FRect
+	src        Rect
+	dst        FRect
 	animation  *Animation
 	animations map[string]*Animation
 }
@@ -21,9 +19,9 @@ func (s *Sprite) SetFPS(fps float64) {
 func NewSprite(texture *Texture, x, y, width, height int) *Sprite {
 	s := &Sprite{
 		Texture: texture,
-		dst: sdl.FRect{
-			W: float32(texture.width),
-			H: float32(texture.height),
+		dst: FRect{
+			Width:  float64(texture.width),
+			Height: float64(texture.height),
 		},
 		animations: make(map[string]*Animation),
 	}
@@ -34,10 +32,10 @@ func NewSprite(texture *Texture, x, y, width, height int) *Sprite {
 }
 
 func (s *Sprite) Crop(x, y, width, height int) {
-	s.src.X = int32(x)
-	s.src.Y = int32(y)
-	s.src.W = int32(width)
-	s.src.H = int32(height)
+	s.src.X = x
+	s.src.Y = y
+	s.src.Width = width
+	s.src.Height = height
 
 	s.animation = nil
 }
@@ -74,18 +72,18 @@ func (s *Sprite) Update(delta float64) {
 }
 
 func (s *Sprite) Draw(x, y float64) {
-	s.dst.X = float32(x)
-	s.dst.Y = float32(y)
+	s.dst.X = x
+	s.dst.Y = y
 
 	if s.animation != nil {
-		s.dst.W = float32(s.animation.frame.src.W)
-		s.dst.H = float32(s.animation.frame.src.H)
+		s.dst.Width = float64(s.animation.frame.src.Width)
+		s.dst.Height = float64(s.animation.frame.src.Height)
 
-		s.Texture.Draw(&s.animation.frame.src, &s.dst, s.animation.frame.flip)
+		s.Texture.DrawRect(&s.animation.frame.src, &s.dst, s.animation.frame.flip)
 	} else {
-		s.dst.W = float32(s.src.W)
-		s.dst.H = float32(s.src.H)
+		s.dst.Width = float64(s.src.Width)
+		s.dst.Height = float64(s.src.Height)
 
-		s.Texture.Draw(&s.src, &s.dst, FlipNone)
+		s.Texture.DrawRect(&s.src, &s.dst, FlipNone)
 	}
 }

--- a/internal/text/face.go
+++ b/internal/text/face.go
@@ -1,0 +1,296 @@
+package text
+
+import (
+	"image"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/robotscone/adventure/internal/gfx"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/opentype"
+	"golang.org/x/image/font/sfnt"
+	"golang.org/x/image/math/fixed"
+)
+
+type Glyph struct {
+	gfx.Rect
+	Advance      fixed.Int26_6
+	BearingLeft  fixed.Int26_6
+	BearingRight fixed.Int26_6
+	Ascent       fixed.Int26_6
+	Descent      fixed.Int26_6
+}
+
+type GlyphRect struct {
+	Src *Glyph
+	Dst Glyph
+}
+
+type Text struct {
+	gfx.FRect
+	Glyphs      []GlyphRect
+	CursorY     int
+	GlyphHeight int
+	LineHeight  int
+}
+
+type Atlas struct {
+	*gfx.Texture
+	Width      int
+	Height     int
+	CellWidth  int
+	CellHeight int
+}
+
+type Face struct {
+	*Atlas
+	ptSize  float64
+	dpi     float64
+	font    *sfnt.Font
+	face    font.Face
+	metrics font.Metrics
+	glyphs  map[rune]*Glyph
+	empty   *Glyph
+	missing *Glyph
+}
+
+func NewFace(fontPath string, ptSize, dpi float64, renderer *gfx.Renderer, scaleQuality gfx.ScaleQuality, charset string) (*Face, error) {
+	b, err := os.ReadFile(fontPath)
+	if err != nil {
+		return nil, err
+	}
+
+	collection, err := opentype.ParseCollection(b)
+	if err != nil {
+		return nil, err
+	}
+
+	tt, err := collection.Font(0)
+	if err != nil {
+		return nil, err
+	}
+
+	face, err := opentype.NewFace(tt, &opentype.FaceOptions{
+		Size:    ptSize,
+		DPI:     dpi,
+		Hinting: font.HintingFull,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	fc := &Face{
+		ptSize:  ptSize,
+		dpi:     dpi,
+		font:    tt,
+		face:    face,
+		metrics: face.Metrics(),
+	}
+
+	fc.generateAtlas(renderer, scaleQuality, charset)
+
+	return fc, nil
+}
+
+func (fc *Face) generateAtlas(renderer *gfx.Renderer, scaleQuality gfx.ScaleQuality, charset string) {
+	missing := '□'
+	charset = strings.NewReplacer("\n", "", "\r", "", "\t", "").Replace(charset) + string(missing)
+
+	runes := []rune(charset)
+	cells := int(math.Round(math.Sqrt(float64(len(runes))) + 0.5))
+	glyphs := make(map[rune]*Glyph, cells)
+	maxCellWidth, maxCellHeight := 0, 0
+
+	for _, r := range runes {
+		bounds, advance, ok := fc.face.GlyphBounds(r)
+		if !ok {
+			bounds, advance, _ = fc.face.GlyphBounds(missing)
+		}
+
+		glyph := &Glyph{
+			Rect: gfx.Rect{
+				Width:  (bounds.Max.X - bounds.Min.X).Ceil(),
+				Height: (fc.metrics.Ascent + fc.metrics.Descent).Ceil(),
+			},
+			Advance:      advance,
+			BearingLeft:  bounds.Min.X,
+			BearingRight: advance - bounds.Max.X,
+			Ascent:       -bounds.Min.Y,
+			Descent:      bounds.Min.Y,
+		}
+
+		if glyph.Width > maxCellWidth {
+			maxCellWidth = glyph.Width + 1
+		}
+
+		if glyph.Height > maxCellHeight {
+			maxCellHeight = glyph.Height + 1
+		}
+
+		glyphs[r] = glyph
+	}
+
+	atlasWidth := maxCellWidth * cells
+	atlasHeight := maxCellHeight * cells
+	img := image.NewGray(image.Rect(0, 0, atlasWidth, atlasHeight))
+	drawer := font.Drawer{
+		Dst:  img,
+		Src:  image.White,
+		Face: fc.face,
+	}
+
+atlasLoop:
+	for y := 0; y < cells; y++ {
+		for x := 0; x < cells; x++ {
+			i := cells*y + x
+
+			if i >= len(runes) {
+				break atlasLoop
+			}
+
+			r := runes[i]
+			glyph := glyphs[r]
+
+			glyph.X = maxCellWidth * x
+			glyph.Y = maxCellHeight * y
+
+			drawer.Dot = fixed.Point26_6{
+				X: fixed.I(glyph.X) - glyph.BearingLeft,
+				Y: fixed.I(glyph.Y) + fc.metrics.Ascent,
+			}
+
+			drawer.DrawString(string(r))
+		}
+	}
+
+	fc.glyphs = glyphs
+	fc.empty = &Glyph{}
+	fc.missing = fc.glyphs[missing]
+	fc.Atlas = &Atlas{
+		Texture:    renderer.NewTexture(img, scaleQuality),
+		Width:      atlasWidth,
+		Height:     atlasHeight,
+		CellWidth:  maxCellWidth - 1,
+		CellHeight: maxCellHeight - 1,
+	}
+}
+
+func (fc *Face) DrawGlyphs(runes []rune) Text {
+	text := Text{
+		GlyphHeight: (fc.metrics.Ascent + fc.metrics.Descent).Ceil(),
+		LineHeight:  fc.metrics.Height.Ceil(),
+	}
+
+	if len(runes) == 0 {
+		return text
+	}
+
+	text.Glyphs = make([]GlyphRect, 0, len(runes))
+
+	// The scale is based on units per em to get as close as possible to a
+	// point size that would represent 100% for the given font
+	// The multiplication by 64 is required before converting float64 to Int26_6
+	scale := fc.dpi / float64(fc.font.UnitsPerEm())
+	kernScale := fixed.Int26_6(fc.ptSize * scale * 64)
+
+	var textWidth fixed.Int26_6
+
+	prev := rune(-1)
+	startX, startY := fixed.I(0), fixed.I(0)
+	x, y := startX, startY
+
+	for _, r := range runes {
+		glyph := fc.glyphs[r]
+		if glyph == nil {
+			glyph = fc.missing
+		}
+
+		var bearingLeft fixed.Int26_6
+		if prev >= 0 {
+			x += fc.face.Kern(prev, r).Mul(kernScale)
+			bearingLeft = glyph.BearingLeft
+		}
+		dstX := x + bearingLeft
+
+		dst := GlyphRect{
+			Src: glyph,
+			Dst: Glyph{
+				Rect: gfx.Rect{
+					X:      dstX.Ceil(),
+					Y:      y.Ceil(),
+					Width:  glyph.Width,
+					Height: glyph.Height,
+				},
+			},
+		}
+
+		switch r {
+		case ' ':
+			dst.Dst.Width = glyph.Advance.Ceil()
+		case '\n':
+			dst.Src = fc.empty
+			dst.Dst.Width = int(float64(text.GlyphHeight) / 2.5) // 2.5 is arbitrary
+			dst.Dst.Height = text.GlyphHeight
+		}
+
+		text.Glyphs = append(text.Glyphs, dst)
+
+		if r != '\n' {
+			x += glyph.Advance
+			if prev < 0 {
+				x -= glyph.BearingLeft
+			}
+		}
+
+		lineWidth := (x - startX) - glyph.BearingRight
+		if lineWidth > textWidth {
+			textWidth = lineWidth
+		}
+
+		prev = r
+
+		if r == '\n' {
+			x = startX
+			y += fc.metrics.Height
+			prev = -1
+		}
+	}
+
+	dst := GlyphRect{
+		Src: fc.empty,
+		Dst: Glyph{
+			Rect: gfx.Rect{
+				X:      x.Ceil(),
+				Y:      y.Ceil(),
+				Width:  int(float64(text.GlyphHeight) / 2.5), // 2.5 is arbitrary
+				Height: text.GlyphHeight,
+			},
+		},
+	}
+
+	text.Glyphs = append(text.Glyphs, dst)
+
+	text.Width = float64(textWidth.Ceil())
+	text.Height = float64(((y - startY) + fc.metrics.Ascent + fc.metrics.Descent).Ceil())
+
+	return text
+}
+
+func (fc *Face) DrawText(x, y, scale float64, runes []rune) Text {
+	text := fc.DrawGlyphs(runes)
+
+	for _, g := range text.Glyphs {
+		dstX := x + float64(g.Dst.X)*scale
+		dstY := y + float64(g.Dst.Y)*scale
+		dstWidth := float64(g.Dst.Width) * scale
+		dstHeight := float64(g.Dst.Height) * scale
+
+		fc.Atlas.Draw(g.Src.X, g.Src.Y, g.Src.Width, g.Src.Height, dstX, dstY, dstWidth, dstHeight, gfx.FlipNone)
+	}
+
+	text.Width *= scale
+	text.Height *= scale
+
+	return text
+}


### PR DESCRIPTION
This PR adds initial support for basic text rendering based on building an atlas of glyphs.

Texture creation has also been updated to help support this, as now it's possible to load greyscale images etc., which when used for font atlases means we can change font colours through modulation, rather than having to build a whole new atlas for every new colour.